### PR TITLE
[TASK] dont break sass building when pure css is imported

### DIFF
--- a/lib/webpack/sass.webpack.js
+++ b/lib/webpack/sass.webpack.js
@@ -28,7 +28,7 @@ const build = (workingDir, conventionalConfig, mode) => {
     module: {
       rules: [
         {
-          test: /\.scss$/,
+          test: /\.[s]?css$/,
           use: [
             {
               loader: MiniCssExtractPlugin.loader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitegeist/conventional",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Frontend toolchain for sitegeist TYPO3 projects",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
Prevent the SASS buildchain from breaking when pure CSS is imported