### PR TITLE
[TASK] Build command exits on error with exit code 1

### DIFF
--- a/lib/actions/build.js
+++ b/lib/actions/build.js
@@ -17,6 +17,14 @@ module.exports = (type, availableTypes, mode, workingDir, config) => {
       return
     }
 
+    stats.stats?.forEach(stat => {
+      if(stat.compilation.errors.length > 0) {
+        throw new Error(
+          stat.compilation.errors.map(err => err.message || err)
+        );
+      }
+    })
+
     console.log(stats.toString({
       colors: true,
       entrypoints: false,


### PR DESCRIPTION
Currently the build command does not exit with an error code if the build pipeline does not succeed. For using conventional in a CI pipeline it must exit with an error code to stop deployment.